### PR TITLE
fix: use the response to get the URL tab

### DIFF
--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -146,7 +146,17 @@ func metricsRun(projects []project.Project, from string, to string, tab string, 
 				return fmt.Errorf("error unmarshalling metrics: %w", err)
 			}
 
-			urlTab := urls[i].Query().Get("tab")
+			var urlTab string
+			switch printable.(type) {
+			case *cauldron.Activity:
+				urlTab = "activity-overview"
+			case *cauldron.Community:
+				urlTab = "community-overview"
+			case *cauldron.Performance:
+				urlTab = "performance-overview"
+			default:
+				urlTab = "overview"
+			}
 
 			var formatter cauldron.Formatter
 			switch format {


### PR DESCRIPTION
Instead of getting the URL in the loop for, which is only used to read from the responses channel, we get the current tab from the response type.
